### PR TITLE
Fix Stats when both IncludeGraph and CalculateStats are true

### DIFF
--- a/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
@@ -107,10 +107,12 @@ public class IncludeGraphTests : IDisposable
         WorkOrder2.Asset.ChildAssets.Add(WorkOrder1.Asset);
 
         var testData = GetTestData().ToList();
-        await db.BulkInsertOrUpdateAsync(testData, new BulkConfig
+        var bulkConfig = new BulkConfig
         {
-            IncludeGraph = true
-        });
+            IncludeGraph = true,
+            CalculateStats = true,
+        };
+        await db.BulkInsertOrUpdateAsync(testData, bulkConfig);
 
         var workOrderQuery = db.WorkOrderSpares
             .Include(y => y.WorkOrder)
@@ -123,6 +125,9 @@ public class IncludeGraphTests : IDisposable
             Assert.NotNull(wos.WorkOrder.Asset);
             Assert.NotNull(wos.Spare);
         }
+
+        Assert.NotNull(bulkConfig.StatsInfo);
+        Assert.Equal(12, bulkConfig.StatsInfo.StatsNumberInserted);
     }
 
     private static IEnumerable<WorkOrder> GetTestData()


### PR DESCRIPTION
I've fixed this by keeping a record of the StatsInfo, and adding the numbers from bulkConfig.StatsInfo to that record after each "merge" action and then replacing the StatsInfo of the bulkConfig with that recorded StatsInfo at the end.

Another option would be to always add the numbers to the stats if they already exist inside the TableInfo.LoadOutputDataAsync method instead of overwriting them there each time. 

This is probably even be cleaner, but might have backward-compatibility issues?